### PR TITLE
chore(deps): ugrade aedes-persistence to 9.1.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,9 +69,9 @@
     "tsd": "^0.14.0"
   },
   "dependencies": {
-    "aedes-persistence": "^9.0.3",
+    "aedes-persistence": "^9.1.1",
     "fastparallel": "^2.4.0",
     "multistream": "^4.0.1",
-    "qlobber": "^5.0.3"
+    "qlobber": "^7.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "tsd": "^0.14.0"
   },
   "dependencies": {
-    "aedes-persistence": "^8.1.3",
+    "aedes-persistence": "^9.0.3",
     "fastparallel": "^2.4.0",
     "multistream": "^4.0.1",
     "qlobber": "^5.0.3"


### PR DESCRIPTION
This PR applies `aedes-persistence@9.0.3`.  While creating this it triggered me to *suggest* restructuring the class inheritance.
: https://github.com/moscajs/aedes-persistence-redis/pull/95#issuecomment-1120398605

I think the implementation of test.js in this PR indicates what it could look like if we restructure the class inheritance ;-)
Just to be sure: this PR does *not* restructure class inheritance ! 

Kind regards,
Hans