### PR TITLE
chore: modernize dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,13 +11,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [14.x, 16.x, 18.x]
+        node-version: ['lts/-1', 'lts/*', 'node']
 
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - name: Use Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # aedes-cached-persistence
 ![](https://github.com/moscajs/aedes-cached-persistence/workflows/ci.yml/badge.svg)
-[![Dependencies Status](https://david-dm.org/moscajs/aedes-cached-persistence/status.svg)](https://david-dm.org/moscajs/aedes-cached-persistence)
-[![devDependencies Status](https://david-dm.org/moscajs/aedes-cached-persistence/dev-status.svg)](https://david-dm.org/moscajs/aedes-cached-persistence?type=dev)
 <br/>
 [![Known Vulnerabilities](https://snyk.io/test/github/moscajs/aedes-cached-persistence/badge.svg)](https://snyk.io/test/github/moscajs/aedes-cached-persistence)
 [![Coverage Status](https://coveralls.io/repos/moscajs/aedes-cached-persistence/badge.svg?branch=master&service=github)](https://coveralls.io/github/moscajs/aedes-cached-persistence?branch=master)

--- a/abstract.js
+++ b/abstract.js
@@ -1,5 +1,3 @@
-'use strict'
-
 const parent = require('aedes-persistence/abstract')
 
 module.exports = parent

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,1 @@
+module.exports = require('neostandard')({})

--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@ const QlobberSub = require('qlobber/aedes/qlobber-sub')
 const { Packet } = require('aedes-persistence')
 const MultiStream = require('multistream')
 const parallel = require('fastparallel')
-const { EventEmitter } = require('events')
+const { EventEmitter } = require('node:events')
 const QlobberOpts = {
   wildcard_one: '+',
   wildcard_some: '#',
@@ -154,8 +154,8 @@ class CachedPersistence extends EventEmitter {
   cleanSubscriptions (client, cb) {
     this.subscriptionsByClient(client, (err, subs, client) => {
       if (err || !subs) { return cb(err, client) }
-      subs = subs.map(subToTopic)
-      this.removeSubscriptions(client, subs, cb)
+      const newSubs = subs.map(subToTopic)
+      this.removeSubscriptions(client, newSubs, cb)
     })
   }
 
@@ -208,7 +208,7 @@ function subToTopic (sub) {
 }
 
 function getKey (clientId, isSub, topic) {
-  return clientId + '-' + (isSub ? 'sub_' : 'unsub_') + (topic || '')
+  return `${clientId}-${isSub ? 'sub_' : 'unsub_'}${topic || ''}`
 }
 
 module.exports = CachedPersistence

--- a/package.json
+++ b/package.json
@@ -1,77 +1,71 @@
 {
-  "name": "aedes-cached-persistence",
-  "version": "9.0.0",
-  "description": "Abstract class to write an Aedes persistence with in-process caching of subscriptions",
-  "main": "index.js",
-  "types": "types/index.d.ts",
-  "scripts": {
-    "lint": "npm run lint:standard",
-    "lint:standard": "standard --verbose | snazzy",
-    "unit": "tape test.js | faucet",
-    "test": "npm run lint && npm run unit && tsd",
-    "test:types": "tsd",
-    "coverage": "nyc --reporter=lcov tape test.js",
-    "test:ci": "npm run lint && npm run coverage",
-    "license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'",
-    "release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
-  },
-  "release-it": {
-    "github": {
-      "release": true
-    },
-    "git": {
-      "tagName": "v${version}"
-    },
-    "hooks": {
-      "before:init": [
-        "npm run test"
-      ]
-    },
-    "npm": {
-      "publish": true
-    }
-  },
-  "pre-commit": [
-    "test"
-  ],
-  "engines": {
-    "node": ">=14"
-  },
-  "repository": {
-    "type": "git",
-    "url": "git+https://github.com/moscajs/aedes-cached-persistence.git"
-  },
-  "keywords": [
-    "aedes",
-    "persistence",
-    "cache",
-    "in-memory"
-  ],
-  "author": "Matteo Collina <hello@matteocollina.com>",
-  "license": "MIT",
-  "bugs": {
-    "url": "https://github.com/moscajs/aedes-cached-persistence/issues"
-  },
-  "homepage": "https://github.com/moscajs/aedes-cached-persistence#readme",
-  "devDependencies": {
-    "aedes": "^0.46.3",
-    "concat-stream": "^2.0.0",
-    "faucet": "0.0.1",
-    "license-checker": "^25.0.1",
-    "mqemitter": "^4.5.0",
-    "nyc": "^15.1.0",
-    "pump": "^3.0.0",
-    "release-it": "^15.0.0",
-    "snazzy": "^9.0.0",
-    "standard": "^17.0.0",
-    "tape": "^5.2.1",
-    "through2": "^4.0.2",
-    "tsd": "^0.20.0"
-  },
-  "dependencies": {
-    "aedes-persistence": "^9.1.2",
-    "fastparallel": "^2.4.1",
-    "multistream": "^4.1.0",
-    "qlobber": "^7.0.0"
-  }
+	"name": "aedes-cached-persistence",
+	"version": "9.0.0",
+	"description": "Abstract class to write an Aedes persistence with in-process caching of subscriptions",
+	"main": "index.js",
+	"types": "types/index.d.ts",
+	"scripts": {
+		"lint": "eslint",
+		"lint:fix": "eslint --fix",
+		"unit": "node --test test.js",
+		"test": "npm run lint && npm run unit && tsd",
+		"test:typescript": "tsd",
+		"coverage": "nyc --reporter=lcov node --test test.js",
+		"test:ci": "npm run lint && npm run coverage && npm run test:typescript",
+		"license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'",
+		"release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
+	},
+	"release-it": {
+		"github": {
+			"release": true
+		},
+		"git": {
+			"tagName": "v${version}"
+		},
+		"hooks": {
+			"before:init": [
+				"npm run test"
+			]
+		},
+		"npm": {
+			"publish": true
+		}
+	},
+	"pre-commit": [
+		"test"
+	],
+	"engines": {
+		"node": ">=20"
+	},
+	"repository": {
+		"type": "git",
+		"url": "git+https://github.com/moscajs/aedes-cached-persistence.git"
+	},
+	"keywords": [
+		"aedes",
+		"persistence",
+		"cache",
+		"in-memory"
+	],
+	"author": "Matteo Collina <hello@matteocollina.com>",
+	"license": "MIT",
+	"bugs": {
+		"url": "https://github.com/moscajs/aedes-cached-persistence/issues"
+	},
+	"homepage": "https://github.com/moscajs/aedes-cached-persistence#readme",
+	"devDependencies": {
+		"aedes": "^0.51.3",
+		"eslint": "^9.21.0",
+		"license-checker": "^25.0.1",
+		"neostandard": "^0.12.1",
+		"nyc": "^17.1.0",
+		"release-it": "^18.1.2",
+		"tsd": "^0.31.2"
+	},
+	"dependencies": {
+		"aedes-persistence": "^10.0.0",
+		"fastparallel": "^2.4.1",
+		"multistream": "^4.1.0",
+		"qlobber": "^8.0.1"
+	}
 }

--- a/test.js
+++ b/test.js
@@ -1,4 +1,4 @@
-const test = require('tape').test
+const test = require('node:test')
 const CachedPersistence = require('./')
 const Memory = require('aedes-persistence')
 const abs = require('./abstract')
@@ -16,9 +16,9 @@ class MyPersistence extends CachedPersistence {
       'createRetainedStream',
       'outgoingStream', 'subscriptionsByClient',
       'getWill', 'streamWill', 'getClientList', 'destroy']
-    methods.forEach((key) => {
+    for (const key of methods) {
       this[key] = this.backend[key].bind(this.backend)
-    })
+    }
     // putWill is a special because it needs this.broker.id
     this.putWill = (client, packet, cb) => {
       this.backend.broker = this.broker

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -5,8 +5,8 @@ import type {
   CallbackError,
   Packet,
 } from 'aedes-persistence';
-import type { EventEmitter } from 'events';
-import type { Readable } from 'stream';
+import type { EventEmitter } from 'node:events';
+import type { Readable } from 'node:stream';
 
 export type { Packet } from 'aedes-persistence';
 

--- a/types/index.test-d.ts
+++ b/types/index.test-d.ts
@@ -4,7 +4,7 @@ import type {
   CallbackError,
 } from 'aedes-persistence';
 import { expectType } from 'tsd';
-import aedesCachedPersistence, { AedesCachedPersistence, Packet } from '.';
+import aedesCachedPersistence, { type AedesCachedPersistence, type Packet } from '.';
 
 expectType<AedesCachedPersistence>(aedesCachedPersistence());
 


### PR DESCRIPTION
This PR adresses #55 :
- updates CI to use the current NodeJS versions
- removes outdated badges from README.md
- replaces `standard` + `snazzy` by `eslint` + `neostandard`
- replaces `tape` + `faucet` by `node:test`
- removes unused dependencies
- updates all other dependencies to their latest versions
- fixes various lint warnings

Kind regards,
Hans