### PR TITLE
fix:  replace tape in README.md by node:test

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ A persistence needs to pass all tests defined in
 in the following manner:
 
 ```js
-var test = require('tape').test
+var test = require('node:test')
 var myperst = require('./')
 var abs = require('aedes-cached-persistence/abstract')
 
@@ -87,7 +87,7 @@ If you require some async stuff before returning, a callback is also
 supported:
 
 ```js
-var test = require('tape').test
+var test = require('node:test')
 var myperst = require('./')
 var abs = require('aedes-persistence/abstract')
 var clean = require('./clean') // invented module

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
 	"homepage": "https://github.com/moscajs/aedes-cached-persistence#readme",
 	"devDependencies": {
 		"aedes": "^0.51.3",
-		"eslint": "^9.21.0",
+		"eslint": "^9.22.0",
 		"license-checker": "^25.0.1",
 		"neostandard": "^0.12.1",
 		"nyc": "^17.1.0",
@@ -63,7 +63,7 @@
 		"tsd": "^0.31.2"
 	},
 	"dependencies": {
-		"aedes-persistence": "^10.0.0",
+		"aedes-persistence": "^10.0.1",
 		"fastparallel": "^2.4.1",
 		"multistream": "^4.1.0",
 		"qlobber": "^8.0.1"


### PR DESCRIPTION
This PR:
-  updates README.md to use node:test in the examples
- updates aedes-persistence and eslint to their latest versions

Kind regards,
Hans