### PR TITLE
chore: update dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
 		"unit": "node --test test.js",
 		"test": "npm run lint && npm run unit && tsd",
 		"test:typescript": "tsd",
-		"coverage": "nyc --reporter=lcov node --test test.js",
+		"coverage": "c8 --reporter=lcov node --test test.js",
 		"test:ci": "npm run lint && npm run coverage && npm run test:typescript",
 		"license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'",
 		"release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
@@ -55,15 +55,15 @@
 	"homepage": "https://github.com/moscajs/aedes-cached-persistence#readme",
 	"devDependencies": {
 		"aedes": "^0.51.3",
-		"eslint": "^9.22.0",
+		"c8": "^10.1.3",
+		"eslint": "^9.25.1",
 		"license-checker": "^25.0.1",
 		"neostandard": "^0.12.1",
-		"nyc": "^17.1.0",
-		"release-it": "^18.1.2",
-		"tsd": "^0.31.2"
+		"release-it": "^19.0.1",
+		"tsd": "^0.32.0"
 	},
 	"dependencies": {
-		"aedes-persistence": "^10.0.1",
+		"aedes-persistence": "^10.0.2",
 		"fastparallel": "^2.4.1",
 		"multistream": "^4.1.0",
 		"qlobber": "^8.0.1"


### PR DESCRIPTION
This PR:
- replaces nyc by c8 to resolve npm audit warnings
- updates the following packages to their latest versions
   - aedes-persistence 10.0.1 => 10.0.2
   - eslint 9.22.0 => 9.25.1
   - tsd 0.31.2 => 0.32.0
   - releaseit 18.1.2 => 19.0.1

releasit claims (as it hard to test in CI) that 19 is just a dependenciy update to 18 without breaking changes

Kind regards,
Hans
