### PR TITLE
feat: addition of callback persistence

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,9 +73,9 @@ A persistence needs to pass all tests defined in
 in the following manner:
 
 ```js
-var test = require('node:test')
-var myperst = require('./')
-var abs = require('aedes-cached-persistence/abstract')
+const test = require('node:test')
+const myperst = require('./')
+const abs = require('aedes-cached-persistence/abstract')
 
 abs({
   test: test,
@@ -87,10 +87,10 @@ If you require some async stuff before returning, a callback is also
 supported:
 
 ```js
-var test = require('node:test')
-var myperst = require('./')
-var abs = require('aedes-persistence/abstract')
-var clean = require('./clean') // invented module
+const test = require('node:test')
+const myperst = require('./')
+const abs = require('aedes-persistence/abstract')
+const clean = require('./clean') // invented module
 
 abs({
   test: test,
@@ -107,5 +107,5 @@ abs({
 
 MIT
 
-[aedes]: http://npm.im/aedes
-[aedes-persistence]: http://npm.im/aedes-persistence
+[aedes]: http://npmjs.com/package/aedes
+[aedes-persistence]: http://npmjs.com/package/aedes-persistence

--- a/callBackPersistence.js
+++ b/callBackPersistence.js
@@ -1,0 +1,250 @@
+'use strict'
+
+/* This module provides a callback layer for async persistence implementations */
+const { Readable } = require('node:stream')
+const CachedPersistence = require('./index.js')
+
+function toValue (obj, prop) {
+  if (typeof obj === 'object' && obj !== null && prop in obj) {
+    return obj[prop]
+  }
+  return obj
+}
+
+class CallBackPersistence extends CachedPersistence {
+  constructor (asyncInstanceFactory, opts = {}) {
+    super(opts)
+    this.asyncPersistence = asyncInstanceFactory(opts)
+  }
+
+  _setup () {
+    if (this.ready) {
+      return
+    }
+    this.asyncPersistence.broker = this.broker
+    this.asyncPersistence._trie = this._trie
+    this.asyncPersistence.setup()
+      .then(() => {
+        this.emit('ready')
+      })
+      .catch(err => {
+        this.emit('error', err)
+      })
+  }
+
+  storeRetained (packet, cb) {
+    if (!this.ready) {
+      this.once('ready', this.storeRetained.bind(this, packet, cb))
+      return
+    }
+    this.asyncPersistence.storeRetained(packet).then(() => {
+      cb(null)
+    }).catch(cb)
+  }
+
+  createRetainedStream (pattern) {
+    return Readable.from(this.asyncPersistence.createRetainedStream(pattern))
+  }
+
+  createRetainedStreamCombi (patterns) {
+    return Readable.from(this.asyncPersistence.createRetainedStreamCombi(patterns))
+  }
+
+  addSubscriptions (client, subs, cb) {
+    if (!this.ready) {
+      this.once('ready', this.addSubscriptions.bind(this, client, subs, cb))
+      return
+    }
+
+    const addSubs1 = this.asyncPersistence.addSubscriptions(client, subs)
+    // promisify
+    const addSubs2 = new Promise((resolve, reject) => {
+      this._addedSubscriptions(client, subs, (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+    Promise.all([addSubs1, addSubs2])
+      .then(() => cb(null, client))
+      .catch(err => cb(err, client))
+  }
+
+  removeSubscriptions (client, subs, cb) {
+    if (!this.ready) {
+      this.once('ready', this.removeSubscriptions.bind(this, client, subs, cb))
+      return
+    }
+
+    const remSubs1 = this.asyncPersistence.removeSubscriptions(client, subs)
+    // promisify
+    const mappedSubs = subs.map(sub => { return { topic: sub } })
+    const remSubs2 = new Promise((resolve, reject) => {
+      this._removedSubscriptions(client, mappedSubs, (err) => {
+        if (err) {
+          reject(err)
+        } else {
+          resolve()
+        }
+      })
+    })
+    Promise.all([remSubs1, remSubs2])
+      .then(() => process.nextTick(cb, null, client))
+      .catch(err => cb(err, client))
+  }
+
+  subscriptionsByClient (client, cb) {
+    if (!this.ready) {
+      this.once('ready', this.subscriptionsByClient.bind(this, client, cb))
+      return
+    }
+
+    this.asyncPersistence.subscriptionsByClient(client)
+      .then(results => {
+        // promisified shim returns an object, true async only the resubs
+        const resubs = results?.resubs || results
+        process.nextTick(cb, null, resubs.length > 0 ? resubs : null, client)
+      })
+      .catch(cb)
+  }
+
+  countOffline (cb) {
+    this.asyncPersistence.countOffline()
+      .then(res => process.nextTick(cb, null, res.subsCount, res.clientsCount))
+      .catch(cb)
+  }
+
+  destroy (cb=noop) {
+    if (!this.ready) {
+      this.once('ready', this.destroy.bind(this, cb))
+      return
+    }
+
+    if (this._destroyed) {
+      throw new Error('destroyed called twice!')
+    }
+
+    this._destroyed = true
+
+    this.asyncPersistence.destroy()
+      .finally(cb) // swallow err in case of failure
+  }
+
+  outgoingEnqueue (sub, packet, cb) {
+    if (!this.ready) {
+      this.once('ready', this.outgoingEnqueue.bind(this, sub, packet, cb))
+      return
+    }
+    this.asyncPersistence.outgoingEnqueue(sub, packet)
+      .then(() => process.nextTick(cb, null, packet))
+      .catch(cb)
+  }
+
+  outgoingEnqueueCombi (subs, packet, cb) {
+    if (!this.ready) {
+      this.once('ready', this.outgoingEnqueueCombi.bind(this, subs, packet, cb))
+      return
+    }
+    this.asyncPersistence.outgoingEnqueueCombi(subs, packet)
+      .then(() => process.nextTick(cb, null, packet))
+      .catch(cb)
+  }
+
+  outgoingStream (client) {
+    return Readable.from(this.asyncPersistence.outgoingStream(client))
+  }
+
+  outgoingUpdate (client, packet, cb) {
+    if (!this.ready) {
+      this.once('ready', this.outgoingUpdate.bind(this, client, packet, cb))
+      return
+    }
+    this.asyncPersistence.outgoingUpdate(client, packet)
+      .then(() => cb(null, client, packet))
+      .catch(cb)
+  }
+
+  outgoingClearMessageId (client, packet, cb) {
+    if (!this.ready) {
+      this.once('ready', this.outgoingClearMessageId.bind(this, client, packet, cb))
+      return
+    }
+    this.asyncPersistence.outgoingClearMessageId(client, packet)
+      .then((packet) => cb(null, packet))
+      .catch(cb)
+  }
+
+  incomingStorePacket (client, packet, cb) {
+    if (!this.ready) {
+      this.once('ready', this.incomingStorePacket.bind(this, client, packet, cb))
+      return
+    }
+    this.asyncPersistence.incomingStorePacket(client, packet)
+      .then(() => cb(null))
+      .catch(cb)
+  }
+
+  incomingGetPacket (client, packet, cb) {
+    if (!this.ready) {
+      this.once('ready', this.incomingGetPacket.bind(this, client, packet, cb))
+      return
+    }
+    this.asyncPersistence.incomingGetPacket(client, packet)
+      .then((packet) => cb(null, packet, client))
+      .catch(cb)
+  }
+
+  incomingDelPacket (client, packet, cb) {
+    if (!this.ready) {
+      this.once('ready', this.incomingDelPacket.bind(this, client, packet, cb))
+      return
+    }
+    this.asyncPersistence.incomingDelPacket(client, packet)
+      .then(() => cb(null))
+      .catch(cb)
+  }
+
+  putWill (client, packet, cb) {
+    if (!this.ready) {
+      this.once('ready', this.putWill.bind(this, client, packet, cb))
+      return
+    }
+    this.asyncPersistence.putWill(client, packet)
+      .then(() => cb(null, client))
+      .catch(cb)
+  }
+
+  getWill (client, cb) {
+    this.asyncPersistence.getWill(client)
+      .then((result) => {
+        // promisified shim returns an object, true async only the resubs
+        const packet = toValue(result, 'packet')
+        cb(null, packet, client)
+      })
+      .catch(cb)
+  }
+
+  delWill (client, cb) {
+    this.asyncPersistence.delWill(client)
+      .then(result => {
+        // promisified shim returns an object, true async only the resubs
+        const packet = toValue(result, 'packet')
+        cb(null, packet, client)
+      })
+      .catch(cb)
+  }
+
+  streamWill (brokers) {
+    return Readable.from(this.asyncPersistence.streamWill(brokers))
+  }
+
+  getClientList (topic) {
+    return Readable.from(this.asyncPersistence.getClientList(topic))
+  }
+}
+
+function noop () {}
+
+module.exports = { CallBackPersistence }

--- a/callBackPersistence.js
+++ b/callBackPersistence.js
@@ -116,7 +116,7 @@ class CallBackPersistence extends CachedPersistence {
       .catch(cb)
   }
 
-  destroy (cb=noop) {
+  destroy (cb = noop) {
     if (!this.ready) {
       this.once('ready', this.destroy.bind(this, cb))
       return

--- a/package.json
+++ b/package.json
@@ -7,10 +7,11 @@
 	"scripts": {
 		"lint": "eslint",
 		"lint:fix": "eslint --fix",
-		"unit": "node --test test.js",
+		"unit": "node --test test/*.js",
 		"test": "npm run lint && npm run unit && tsd",
 		"test:typescript": "tsd",
-		"coverage": "c8 --reporter=lcov node --test test.js",
+		"coverage": "c8 --reporter=lcov npm run unit",
+		"coverage:report": "c8 report",
 		"test:ci": "npm run lint && npm run coverage && npm run test:typescript",
 		"license-checker": "license-checker --production --onlyAllow='MIT;ISC;BSD-3-Clause;BSD-2-Clause'",
 		"release": "read -p 'GITHUB_TOKEN: ' GITHUB_TOKEN && export GITHUB_TOKEN=$GITHUB_TOKEN && release-it --disable-metrics"
@@ -63,7 +64,7 @@
 		"tsd": "^0.32.0"
 	},
 	"dependencies": {
-		"aedes-persistence": "^10.0.2",
+		"aedes-persistence": "^10.1.0",
 		"fastparallel": "^2.4.1",
 		"multistream": "^4.1.0",
 		"qlobber": "^8.0.1"

--- a/package.json
+++ b/package.json
@@ -66,7 +66,6 @@
 	"dependencies": {
 		"aedes-persistence": "^10.1.0",
 		"fastparallel": "^2.4.1",
-		"multistream": "^4.1.0",
 		"qlobber": "^8.0.1"
 	}
 }

--- a/promisified.js
+++ b/promisified.js
@@ -1,0 +1,3 @@
+const parent = require('aedes-persistence/promisified')
+
+module.exports = parent

--- a/test/helpers/testPersistence.js
+++ b/test/helpers/testPersistence.js
@@ -1,9 +1,7 @@
-const test = require('node:test')
-const CachedPersistence = require('./')
-const Memory = require('aedes-persistence')
-const abs = require('./abstract')
+'use strict'
+const CachedPersistence = require('../..')
 
-class MyPersistence extends CachedPersistence {
+class TestPersistence extends CachedPersistence {
   constructor (opts) {
     super(opts)
     this.backend = opts.backend
@@ -19,6 +17,7 @@ class MyPersistence extends CachedPersistence {
     for (const key of methods) {
       this[key] = this.backend[key].bind(this.backend)
     }
+
     // putWill is a special because it needs this.broker.id
     this.putWill = (client, packet, cb) => {
       this.backend.broker = this.broker
@@ -48,9 +47,4 @@ class MyPersistence extends CachedPersistence {
   }
 }
 
-const persistence = () => new MyPersistence({ backend: Memory() })
-
-abs({
-  test,
-  persistence
-})
+module.exports = { TestPersistence }

--- a/test/test-callBackPersistence.js
+++ b/test/test-callBackPersistence.js
@@ -1,0 +1,21 @@
+const test = require('node:test')
+
+const { PromisifiedPersistence } = require('../promisified.js')
+const { CallBackPersistence } = require('../callBackPersistence.js')
+const { TestPersistence } = require('./helpers/testPersistence.js')
+const Memory = require('aedes-persistence')
+const abs = require('../abstract.js')
+
+const persistence = (opts) => {
+  const asyncInstanceFactory = () => {
+    const instance = new PromisifiedPersistence(new TestPersistence({ backend: Memory() }))
+    instance.setup = async () => {}
+    return instance
+  }
+  return new CallBackPersistence(asyncInstanceFactory, opts)
+}
+
+abs({
+  test,
+  persistence
+})

--- a/test/test-own.js
+++ b/test/test-own.js
@@ -1,0 +1,11 @@
+const test = require('node:test')
+const Memory = require('aedes-persistence')
+const abs = require('../abstract')
+const { TestPersistence } = require('./helpers/testPersistence.js')
+
+const persistence = () => new TestPersistence({ backend: Memory() })
+
+abs({
+  test,
+  persistence
+})

--- a/test/test-promisified.js
+++ b/test/test-promisified.js
@@ -1,0 +1,31 @@
+const test = require('node:test')
+const { TestPersistence } = require('./helpers/testPersistence.js')
+const { PromisifiedPersistence } = require('../promisified.js')
+const Memory = require('aedes-persistence')
+
+const persistence = () => new TestPersistence({ backend: Memory() })
+
+// basic check of promisified,the full test has already been done in abs()
+test('promisified', async (t) => {
+  t.plan(1)
+  const client = {
+    id: 'abcde'
+  }
+  const packet = {
+    cmd: 'publish',
+    topic: 'hello',
+    payload: Buffer.from('world'),
+    qos: 2,
+    dup: false,
+    length: 14,
+    retain: false,
+    messageId: 42
+  }
+  const p = new PromisifiedPersistence(persistence())
+
+  await p.incomingStorePacket(client, packet)
+  const retrieved = await p.incomingGetPacket(client, {
+    messageId: packet.messageId
+  })
+  t.assert.equal(retrieved.topic, 'hello')
+})


### PR DESCRIPTION
This PR:

- updates aedes-persistence to its latest version
- adds callBackPersistence that contains the common code to bridge callback to async as used in aedes-persistence-mongodb and  aedes-persistence-redis
- re-exports promisified.js from aedes-persistence
- restructures the existing test in subfiles to ease testing
- adds tests for callBackPersistence and promisified.js
- adds coverage:report to package.json to ease checking of coverage
- replaces 'var' by 'const' in the examples in README.md
- updates the links in README.md from npm.im to npm.js
-  replaces multistream as a dependency by a native implementation

Kind regards,
Hans